### PR TITLE
Added additional comment for process restarting.

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -112,6 +112,7 @@ addgroup postfix abuseio
 addgroup www-data abuseio
 ```
 > You will need to restart Apache and Postfix in this example to make your changes active!
+> When you're running php-fpm as www-data, you need to restart that as well.
 
 
 # Installation


### PR DESCRIPTION
When using php-fpm (for example when running in nginx) and php-fpm is
running as user www-data, it needs to be restarted as well when user
www-data is added to group abuseio.