### PR TITLE
Fixed typo in 'newaliases'.

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -221,7 +221,7 @@ postconf -e transport_maps=hash:/etc/postfix/transport
 /etc/aliases:
 ```bash
 echo "notifier: notifier@isp.local" >> /etc/aliases
-newaliasses
+newaliases
 ```
 
 Add this to /etc/postfix/master.cf:


### PR DESCRIPTION
It's spelt newaliases instead of newaliasses (credits to munkster).